### PR TITLE
Upgrade educabiz to 0.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,63 @@
-# python package template
+# tgbot-educabiz
 
-## Content
+Telegram bot for Educabiz.
 
-* `pytest` for tests: `make test`
-* `ruff` for linting/formatting: `make lint` (replaces both `black` and `isort`)
-* `uv` for dependency and virtualenv management (`uv sync --dev`)
-* `.github` with actions ready to test PRs and publish releases
+## Configuration
 
-## New project checklist
+The bot reads configuration from environment variables and from `.env.app` when
+that file exists.
 
-* [ ] Replace `example` with *the* package
-* [ ] Replace `LICENSE` if MIT does not apply
-* [ ] Search the project for `# TODO` to find the (minimum list of) places that need to be changed.
-* [ ] Add PYPI credentials to secrets
+Required settings:
+
+```env
+TGEB_TOKEN=123456:telegram-bot-token
+
+TGEB_LOGIN_SCHOOL1_USERNAME=parent@example.com
+TGEB_LOGIN_SCHOOL1_PASSWORD=school-1-password
+
+TGEB_CHATID_123456789=SCHOOL1
+```
+
+`TGEB_CHATID_<telegram chat id>` maps a Telegram chat to one or more Educabiz
+login profiles. To include multiple profiles in the same chat, separate profile
+names with commas.
+
+## Using Multiple Schools
+
+Educabiz does not provide a way to choose the school during login, matching the
+behavior of the Educabiz mobile app.
+
+The portal redirects to the right school based on the unique email/password
+combination, so when using multiple schools with the same email address, use the
+password associated with the intended school. If the same password is currently
+used for multiple schools, log in to the first school that opens and change the
+password there.
+
+The old password will then redirect to the other school.
+
+Example with two schools using the same email address and different passwords:
+
+```env
+TGEB_TOKEN=123456:telegram-bot-token
+
+TGEB_LOGIN_SCHOOL1_USERNAME=parent@example.com
+TGEB_LOGIN_SCHOOL1_PASSWORD=password-for-first-school
+
+TGEB_LOGIN_SCHOOL2_USERNAME=parent@example.com
+TGEB_LOGIN_SCHOOL2_PASSWORD=password-for-second-school
+
+TGEB_CHATID_123456789=SCHOOL1,SCHOOL2
+```
+
+In this example, messages in Telegram chat `123456789` can use both Educabiz
+profiles. `SCHOOL1` and `SCHOOL2` are just profile names; the bot matches them
+to the corresponding `TGEB_LOGIN_<profile>_USERNAME` and
+`TGEB_LOGIN_<profile>_PASSWORD` variables.
+
+## Development
+
+```sh
+uv sync --dev
+make test
+make lint
+```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ names with commas.
 
 ## Using Multiple Schools
 
+This note is copied from the
+[`python-educabiz` README](https://github.com/fopina/python-educabiz#using-multiple-schools).
+
 Educabiz does not provide a way to choose the school during login, matching the
 behavior of the Educabiz mobile app.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Telegram bot for Educabiz"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "educabiz",
+    "educabiz>=0.0.6",
     "pydantic",
     "python-dotenv",
     "python-telegram-bot[webhooks]",

--- a/uv.lock
+++ b/uv.lock
@@ -257,15 +257,15 @@ toml = [
 
 [[package]]
 name = "educabiz"
-version = "0.0.5"
+version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/2c/d72e27d95dc829c944f3d32128c9d2bf09c5e1cf8d0cb7b20ca80498b5d6/educabiz-0.0.5.tar.gz", hash = "sha256:10036214c7aad95100db853fee2d78a571ed230e200a1baa72d21a6275d631ab", size = 5853, upload-time = "2024-10-29T13:57:28.183Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/6f/6ff19cd130d3218ebcf38ab6a2ff3809f475e3a7916e3896518e90793e05/educabiz-0.0.6.tar.gz", hash = "sha256:d22d92c99fa24884888ea1ce884558fa8ca53787704ee46931a8669fd21abab3", size = 6408, upload-time = "2026-07-04T09:56:24.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/72/693e81e18d5f6e4f9c091050ec8c864df02a19f0cd7d562020fac84c265e/educabiz-0.0.5-py3-none-any.whl", hash = "sha256:488573f39ca8032f8177deea6aac523e1b2e5cf6ee12932486b630acc1abe9f6", size = 6367, upload-time = "2024-10-29T13:57:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/88/506055d3a97ec63f5cad5ac96f19beb0b724dda57daaba0975c9fad1c57f/educabiz-0.0.6-py3-none-any.whl", hash = "sha256:dad1a785ee936ccfb0ba31b994f2b431d5821f9c6a034690fd5060e97bd796a1", size = 6715, upload-time = "2026-07-04T09:56:23.911Z" },
 ]
 
 [[package]]
@@ -611,7 +611,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "educabiz" },
+    { name = "educabiz", specifier = ">=0.0.6" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot", extras = ["webhooks"] },


### PR DESCRIPTION
## Summary
- require `educabiz>=0.0.6`
- refresh `uv.lock` to use `educabiz` 0.0.6
- pick up the UTF-8 BOM JSON response fix from fopina/python-educabiz#10
- document how Educabiz handles multiple schools and show this bot's multi-profile configuration

## Tests
- `make test`
