### PR TITLE
Fix start handler continuing after missing child photo

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,4 +1,8 @@
-from tgbot_educabiz.bot import PresenceCheck
+import asyncio
+from types import SimpleNamespace
+from unittest import mock
+
+from tgbot_educabiz.bot import Bot, PresenceCheck
 
 from . import Base
 
@@ -43,3 +47,35 @@ class Test(Base):
         self.assertEqual(ci.hasOut, False)
         self.assertEqual(ci.entry_in.time, '09:52')
         self.assertEqual(ci.entry_out.time, '')
+
+    def test_start_continues_after_child_without_photo(self):
+        def child(child_id, name):
+            return SimpleNamespace(
+                id=child_id,
+                name=name,
+                presence=[SimpleNamespace(id='undefined', absent=False, hourIn=None, hourOut=None)],
+            )
+
+        children = {
+            'first': child('first', 'First Child'),
+            'second': child('second', 'Second Child'),
+        }
+        eb = mock.Mock()
+        eb.school_qrcodeinfo.return_value = SimpleNamespace(child=children)
+        eb.home.return_value = SimpleNamespace(
+            children={
+                'first': SimpleNamespace(photo=None),
+                'second': SimpleNamespace(photo='https://example.invalid/second.jpg'),
+            }
+        )
+
+        message = mock.AsyncMock()
+        update = SimpleNamespace(effective_user=SimpleNamespace(id=123), message=message)
+        bot = Bot(token='token', chat_ids={123: [eb]})
+
+        asyncio.run(bot.start(update, mock.Mock()))
+
+        message.reply_markdown_v2.assert_awaited_once()
+        message.reply_photo.assert_awaited_once()
+        self.assertIn('First Child', message.reply_markdown_v2.await_args.args[0])
+        self.assertIn('Second Child', message.reply_photo.await_args.kwargs['caption'])

--- a/tgbot_educabiz/bot.py
+++ b/tgbot_educabiz/bot.py
@@ -94,7 +94,7 @@ class Bot:
 {escape_markdown(presence_str, version=2)}"""
 
                 if photo is None:
-                    return await update.message.reply_markdown_v2(
+                    await update.message.reply_markdown_v2(
                         message,
                         reply_markup=reply_markup,
                     )


### PR DESCRIPTION
## Summary

- Retrofit diogonmoura/educabiz-bot@51d52043448f7d731ec8dc7620042c2095d74763
- Continue iterating `/start` children after replying for a child without a photo
- Add regression coverage proving a later child with a photo is still sent

## Tests

- `uv run pytest`
- `uv run ruff check .`
- `git diff --check`

## Thanks
@diogonmoura