### PR TITLE
Show fetcher in presence confirmations

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -40,13 +40,17 @@ class Test(Base):
         co = PresenceCheck.model_validate(check_out_response)
         self.assertEqual(co.hasIn, True)
         self.assertEqual(co.hasOut, True)
+        self.assertEqual(co.entry_in.fetcher, 'Pai')
         self.assertEqual(co.entry_out.time, '17:11')
+        self.assertEqual(co.entry_out.fetcher, 'Mãe')
 
         ci = PresenceCheck.model_validate(check_in_response)
         self.assertEqual(ci.hasIn, True)
         self.assertEqual(ci.hasOut, False)
         self.assertEqual(ci.entry_in.time, '09:52')
+        self.assertEqual(ci.entry_in.fetcher, 'Pai')
         self.assertEqual(ci.entry_out.time, '')
+        self.assertEqual(ci.entry_out.fetcher, '')
 
     def test_start_continues_after_child_without_photo(self):
         def child(child_id, name):

--- a/tgbot_educabiz/bot.py
+++ b/tgbot_educabiz/bot.py
@@ -169,14 +169,17 @@ class Bot:
                 logger.debug('CHECKIN RESPONSE: %s', r)
                 cd = PresenceCheck.model_validate(r)
                 logger.info(f'{update.effective_user.id} checked IN {child_id}')
-                return await query.edit_message_caption(f'🛬 Checked in at {cd.entry_in.time}')
+                fetcher = f' by {cd.entry_in.fetcher}' if cd.entry_in.fetcher else ''
+                return await query.edit_message_caption(f'🛬 Checked in at {cd.entry_in.time}{fetcher}')
             elif tail == 'checkout':
                 r = eb.child_check_out(child_id)
                 logger.debug('CHECKOUT RESPONSE: %s', r)
                 cd = PresenceCheck.model_validate(r)
                 logger.info(f'{update.effective_user.id} checked OUT {child_id}')
+                fetcher_in = f' by {cd.entry_in.fetcher}' if cd.entry_in and cd.entry_in.fetcher else ''
+                fetcher_out = f' by {cd.entry_out.fetcher}' if cd.entry_out and cd.entry_out.fetcher else ''
                 return await query.edit_message_caption(
-                    f'🛬 Check in: {cd.entry_in.time}\n🚶‍♂️ Check out: {cd.entry_out.time}'
+                    f'🛬 Check in: {cd.entry_in.time}{fetcher_in}\n🚶‍♂️ Check out: {cd.entry_out.time}{fetcher_out}'
                 )
             if tail == 'sickleave':
                 # FIXME: update once a sample is available
@@ -212,6 +215,7 @@ class PresenceCheckEntry(BaseModel):
     model_config = {'extra': 'allow'}
 
     time: str = None
+    fetcher: str = None
 
     @field_validator('time')
     def parse_hours(cls, value):


### PR DESCRIPTION
## Summary

- show the fetcher/parent name in check-in confirmation captions when available
- show fetcher names for both check-in and check-out rows after checkout
- add model assertions for the `fetcher` field

## Tests

- `make test`

## Thanks
@diogonmoura
