### PR TITLE
Add webhook listen configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ Supported settings:
 | `TGEB_ABSENT_DEFAULT_NOTE` | No | | Note sent when marking a child absent/sick. |
 | `TGEB_WEBHOOK_URL` | No | | Public webhook URL. When set, the bot uses Telegram webhooks instead of polling. |
 | `TGEB_WEBHOOK_PORT` | No | `9999` | Local port used by the webhook server. |
+| `TGEB_WEBHOOK_LISTEN` | No | | Local address used by the webhook server. |
 
 The `_FILE` suffix works for all of these variables, including grouped
 variables such as `TGEB_LOGIN_SCHOOL1_PASSWORD_FILE` or
 `TGEB_CHATID_123456789_FILE`.
 
 Without `TGEB_WEBHOOK_URL`, the bot runs with Telegram long polling. With
-`TGEB_WEBHOOK_URL`, it starts a webhook server on `TGEB_WEBHOOK_PORT`.
+`TGEB_WEBHOOK_URL`, it starts a webhook server on `TGEB_WEBHOOK_PORT`. Set
+`TGEB_WEBHOOK_LISTEN` to choose the local address the webhook server binds to.
 
 ## Using Multiple Schools
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -89,3 +89,24 @@ class Test(Base):
         bot = Bot(token='token', chat_ids={})
 
         json.dumps({'secret_token': bot._secret_token})
+
+    def test_run_webhook_uses_configured_listen_address(self):
+        bot = Bot(
+            token='token',
+            webhook_url='https://example.invalid/webhook',
+            webhook_port=8080,
+            webhook_listen='127.0.0.1',
+            chat_ids={},
+        )
+        application = mock.Mock()
+
+        with mock.patch.object(bot, 'setup_app', return_value=application):
+            bot.run()
+
+        application.run_webhook.assert_called_once()
+        self.assertEqual(application.run_webhook.call_args.kwargs['port'], 8080)
+        self.assertEqual(application.run_webhook.call_args.kwargs['listen'], '127.0.0.1')
+        self.assertEqual(
+            application.run_webhook.call_args.kwargs['webhook_url'],
+            'https://example.invalid/webhook',
+        )

--- a/tgbot_educabiz/__main__.py
+++ b/tgbot_educabiz/__main__.py
@@ -58,6 +58,7 @@ def main() -> None:
     bot = Bot(
         env('TGEB_TOKEN'),
         webhook_port=env('TGEB_WEBHOOK_PORT', 9999),
+        webhook_listen=env('TGEB_WEBHOOK_LISTEN'),
         webhook_url=env('TGEB_WEBHOOK_URL'),
         chat_ids=chat_ids,
         absent_note=env('TGEB_ABSENT_DEFAULT_NOTE'),

--- a/tgbot_educabiz/bot.py
+++ b/tgbot_educabiz/bot.py
@@ -23,12 +23,14 @@ class Bot:
         token: str,
         webhook_url: str = None,
         webhook_port: int = None,
+        webhook_listen: str = None,
         chat_ids: dict[str, list['EBClient']] = None,
         absent_note: str = None,
     ):
         self._token = token
         self._webhook_url = webhook_url
         self._webhook_port = webhook_port
+        self._webhook_listen = webhook_listen
         self._secret_token = str(uuid.uuid4())
         self._chat_ids = chat_ids
         self._absent_note = absent_note
@@ -197,6 +199,7 @@ class Bot:
             # TODO: check with upstream if random secret_token should not be handled BY DEFAULT
             application.run_webhook(
                 port=self._webhook_port,
+                listen=self._webhook_listen,
                 webhook_url=self._webhook_url,
                 secret_token=self._secret_token,
                 allowed_updates=Update.ALL_TYPES,


### PR DESCRIPTION
## Summary

- add `TGEB_WEBHOOK_LISTEN` support for webhook bind address configuration
- pass the configured value as `listen` to `Application.run_webhook`
- document the new setting and cover it with a unit test

## Tests

- `make test`
- `make lint`
